### PR TITLE
refactor(input): migrate InputGAgent to use MemberGAgentBase

### DIFF
--- a/src/Aevatar.GAgents.GroupChat.GroupMember/Aevatar.GAgents.GroupChat.GroupMember.csproj
+++ b/src/Aevatar.GAgents.GroupChat.GroupMember/Aevatar.GAgents.GroupChat.GroupMember.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Aevatar.Core" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Aevatar.GAgents.AIGAgent\Aevatar.GAgents.AIGAgent.csproj" />
+      <ProjectReference Include="..\Aevatar.GAgents.GroupChat\Aevatar.GAgents.GroupChat.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/Dto/MemberConfigDto.cs
+++ b/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/Dto/MemberConfigDto.cs
@@ -1,0 +1,12 @@
+// ABOUTME: This file implements the configuration DTO for group member agents
+// ABOUTME: Defines the configuration structure for initializing member agents
+
+using Aevatar.Core.Abstractions;
+
+namespace GroupChat.GAgent.Dto;
+
+[GenerateSerializer]
+public class MemberConfigDto:ConfigurationBase
+{
+    [Id(0)] public string MemberName { get; set; }
+}

--- a/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/LogEvent/MemberState.cs
+++ b/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/LogEvent/MemberState.cs
@@ -1,0 +1,12 @@
+// ABOUTME: This file implements the state class for group member agents
+// ABOUTME: Contains the persistent state information for member agents including member name
+
+using Aevatar.Core.Abstractions;
+
+namespace GroupChat.GAgent.GEvent;
+
+[GenerateSerializer]
+public class MemberState : StateBase
+{
+    [Id(0)] public string MemberName { get; set; }
+}

--- a/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/MemberGAgentBase.cs
+++ b/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/MemberGAgentBase.cs
@@ -1,0 +1,117 @@
+// ABOUTME: This file implements the base class for group member agents
+// ABOUTME: Provides common functionality for handling group chat events and member interactions
+
+using Aevatar.Core;
+using GroupChat.GAgent.Feature.Common;
+using GroupChat.GAgent.GEvent;
+using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.AIGAgent.Agent;
+using GroupChat.GAgent.Dto;
+using GroupChat.GAgent.Feature.Blackboard;
+using GroupChat.GAgent.Feature.Coordinator.GEvent;
+
+namespace GroupChat.GAgent;
+
+public abstract partial class
+    MemberGAgentBase<TState, TStateLogEvent, TEvent, TConfiguration> :
+    GAgentBase<TState, TStateLogEvent, TEvent, TConfiguration>
+    where TState : MemberState, new()
+    where TStateLogEvent : StateLogEventBase<TStateLogEvent>
+    where TEvent : EventBase
+    where TConfiguration : MemberConfigDto
+{
+    [EventHandler]
+    public async Task HandleEventAsync(EvaluationInterestEvent @event)
+    {
+        var score = await GetInterestValueAsync(@event.BlackboardId);
+
+        await PublishAsync(new EvaluationInterestResponseEvent()
+        {
+            MemberId = this.GetPrimaryKey(), BlackboardId = @event.BlackboardId, InterestValue = score,
+            ChatTerm = @event.ChatTerm
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleEventAsync(ChatEvent @event)
+    {
+        if (@event.Speaker != this.GetPrimaryKey())
+        {
+            return;
+        }
+
+        // var history = await GetCareChatMessagesFromBlackboardAsync(@event.BlackboardId);
+        var talkResponse = await ChatAsync(@event.BlackboardId, @event.CoordinatorMessages);
+        await PublishAsync(new ChatResponseEvent()
+        {
+            BlackboardId = @event.BlackboardId, MemberId = this.GetPrimaryKey(), MemberName = State.MemberName,
+            ChatResponse = talkResponse, Term = @event.Term
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleEventAsync(GroupChatFinishEvent @event)
+    {
+        await GroupChatFinishAsync(@event.BlackboardId);
+    }
+
+    [EventHandler]
+    public async Task HandleEventAsync(CoordinatorPingEvent @event)
+    {
+        if (await IgnoreBlackboardPingEvent(@event.BlackboardId) == false)
+        {
+            await PublishAsync(new CoordinatorPongEvent()
+                { BlackboardId = @event.BlackboardId, MemberId = this.GetPrimaryKey(), MemberName = State.MemberName });
+        }
+    }
+
+    protected abstract Task<int> GetInterestValueAsync(Guid blackboardId);
+
+    protected abstract Task<ChatResponse> ChatAsync(Guid blackboardId, List<ChatMessage>? coordinatorMessages);
+
+    protected virtual Task GroupChatFinishAsync(Guid blackboardId)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task<bool> IgnoreBlackboardPingEvent(Guid blackboardId)
+    {
+        return Task.FromResult(false);
+    }
+
+    [GenerateSerializer]
+    public class SetMemberNameLogEvent : StateLogEventBase<TStateLogEvent>
+    {
+        [Id(0)] public string MemberName { get; set; }
+    }
+
+    protected override async Task PerformConfigAsync(TConfiguration configuration)
+    {
+        RaiseEvent(new SetMemberNameLogEvent() { MemberName = configuration.MemberName });
+        await ConfirmEvents();
+    }
+
+    protected override void GAgentTransitionState(TState state, StateLogEventBase<TStateLogEvent> @event)
+    {
+        switch (@event)
+        {
+            case SetMemberNameLogEvent @setMemberNameLogEvent:
+                State.MemberName = @setMemberNameLogEvent.MemberName;
+                return;
+        }
+
+        MemberTransitionState(state, @event);
+    }
+
+    protected virtual void MemberTransitionState(TState state, StateLogEventBase<TStateLogEvent> @event)
+    {
+    }
+
+    protected async Task<List<ChatMessage>> GetMessageFromBlackboardAsync(Guid blackboardId)
+    {
+        var blackboard = GrainFactory.GetGrain<IBlackboardGAgent>(blackboardId);
+        var history = await blackboard.GetContent();
+
+        return history;
+    }
+}

--- a/src/Aevatar.GAgents.InputGAgent/Aevatar.GAgents.InputGAgent.csproj
+++ b/src/Aevatar.GAgents.InputGAgent/Aevatar.GAgents.InputGAgent.csproj
@@ -13,7 +13,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Aevatar.GAgents.GroupChat\Aevatar.GAgents.GroupChat.csproj" />
       <ProjectReference Include="..\Aevatar.GAgents.GroupChat.GroupMember\Aevatar.GAgents.GroupChat.GroupMember.csproj" />
     </ItemGroup>
 

--- a/src/Aevatar.GAgents.InputGAgent/Aevatar.GAgents.InputGAgent.csproj
+++ b/src/Aevatar.GAgents.InputGAgent/Aevatar.GAgents.InputGAgent.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Aevatar.GAgents.GroupChat\Aevatar.GAgents.GroupChat.csproj" />
+      <ProjectReference Include="..\Aevatar.GAgents.GroupChat.GroupMember\Aevatar.GAgents.GroupChat.GroupMember.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Aevatar.GAgents.InputGAgent/Dto/InputConfigDto.cs
+++ b/src/Aevatar.GAgents.InputGAgent/Dto/InputConfigDto.cs
@@ -7,7 +7,7 @@ using GroupChat.GAgent.Dto;
 namespace Aevatar.GAgents.InputGAgent.Dto;
 
 [GenerateSerializer]
-public class InputConfigDto : GroupMemberConfigDto
+public class InputConfigDto : MemberConfigDto
 {
     [Id(1)] public string Input { get; set; } = string.Empty;
 }

--- a/src/Aevatar.GAgents.InputGAgent/GAgent/InputGAgent.cs
+++ b/src/Aevatar.GAgents.InputGAgent/GAgent/InputGAgent.cs
@@ -13,7 +13,7 @@ namespace Aevatar.GAgents.InputGAgent.GAgent;
 [StorageProvider(ProviderName = "PubSubStore")]
 [LogConsistencyProvider(ProviderName = "LogStorage")]
 [GAgent(nameof(InputGAgent))]
-public class InputGAgent : GroupMemberGAgentBase<InputGAgentState, InputGAgentLogEvent, EventBase, InputConfigDto>, IInputGAgent
+public class InputGAgent : MemberGAgentBase<InputGAgentState, InputGAgentLogEvent, EventBase, InputConfigDto>, IInputGAgent
 {
     public override Task<string> GetDescriptionAsync()
     {
@@ -50,7 +50,7 @@ public class InputGAgent : GroupMemberGAgentBase<InputGAgentState, InputGAgentLo
         await ConfirmEvents();
     }
 
-    protected override void GroupMemberTransitionState(InputGAgentState state, StateLogEventBase<InputGAgentLogEvent> @event)
+    protected override void MemberTransitionState(InputGAgentState state, StateLogEventBase<InputGAgentLogEvent> @event)
     {
         switch (@event)
         {

--- a/src/Aevatar.GAgents.InputGAgent/GAgent/SEvent/InputGAgentState.cs
+++ b/src/Aevatar.GAgents.InputGAgent/GAgent/SEvent/InputGAgentState.cs
@@ -6,7 +6,7 @@ using GroupChat.GAgent.GEvent;
 namespace Aevatar.GAgents.InputGAgent.GAgent.SEvent;
 
 [GenerateSerializer]
-public class InputGAgentState : GroupMemberState
+public class InputGAgentState : MemberState
 {
     [Id(1)] public string Input { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- Migrated InputGAgent to inherit from MemberGAgentBase instead of GroupMemberGAgentBase
- Updated related classes (InputConfigDto, InputGAgentState) to use new base classes
- Added project reference to Aevatar.GAgents.GroupChat.GroupMember
- Updated method name from GroupMemberTransitionState to MemberTransitionState

## Test plan
- [x] Build succeeds without compile errors
- [x] All inheritance relationships are correctly established
- [x] Method signatures match the new base class requirements

🤖 Generated with [Claude Code](https://claude.ai/code)